### PR TITLE
EGS game path detection.

### DIFF
--- a/src/gamefallout3.cpp
+++ b/src/gamefallout3.cpp
@@ -48,6 +48,24 @@ bool GameFallout3::init(IOrganizer *moInfo)
   return true;
 }
 
+QString GameFallout3::identifyGamePath() const
+{
+  auto result = GameGamebryo::identifyGamePath();  // Default registry path
+  // EPIC Game Store
+  if (result.isEmpty()) {
+    // Fallout 3: Game of the Year Edition: adeae8bbfc94427db57c7dfecce3f1d4
+    result = parseEpicGamesLocation({ "adeae8bbfc94427db57c7dfecce3f1d4" });
+    if (QFileInfo(result).isDir()) {
+      QDir startPath = QDir(result);
+      auto subDirs = startPath.entryList({ "Fallout 3 GOTY*" },
+        QDir::Dirs | QDir::NoDotAndDotDot);
+      if (!subDirs.isEmpty())
+        result = startPath.absoluteFilePath(subDirs.first());
+    }
+  }
+  return result;
+}
+
 QString GameFallout3::gameName() const
 {
   return "Fallout 3";

--- a/src/gamefallout3.h
+++ b/src/gamefallout3.h
@@ -46,7 +46,7 @@ public: // IPlugin interface
   virtual QList<MOBase::PluginSetting> settings() const override;
 
 protected:
-
+  virtual QString identifyGamePath() const override;
   virtual QString savegameExtension() const override;
   virtual QString savegameSEExtension() const override;
   std::shared_ptr<const GamebryoSaveGame> makeSaveGame(QString filePath) const override;


### PR DESCRIPTION
The Epic Games version of Fallout 3 does not seem to create the normal registry key, so it can use the EGS specific detection.
I do not see any other areas that need vendor specific code.