### PR TITLE
Add variants and remove custom.ini

### DIFF
--- a/src/gamefallout3.cpp
+++ b/src/gamefallout3.cpp
@@ -49,18 +49,18 @@ bool GameFallout3::init(IOrganizer* moInfo)
   return true;
 }
 
-void GameFallout3::checkVariants()
+QString GameFallout3::identifyVariant() const
 {
   if (QFile::exists(m_GamePath + "/Fallout3ng.exe")) {
-    setGameVariant("Low Violence");
+    return "Low Violence";
   } else if (QFile::exists(m_GamePath + "/Galaxy.dll")) {
-    setGameVariant("GOG");
+    return "GOG";
   } else if (QFile::exists(m_GamePath + "/FalloutLauncherEpic.exe")) {
-    setGameVariant("Epic Games");
+    return "Epic Games";
   } else if (m_GamePath.endsWith("Fallout 3 goty")) {
-    setGameVariant("Steam (Game of the Year)");
+    return "Steam (Game of the Year)";
   } else {
-    setGameVariant("Steam (Regular)");
+    return "Steam (Regular)";
   }
 }
 
@@ -103,7 +103,7 @@ QString GameFallout3::gameName() const
 void GameFallout3::detectGame()
 {
   m_GamePath = identifyGamePath();
-  checkVariants();
+  setGameVariant(identifyVariant());
   m_MyGamesPath = determineMyGamesPath("Fallout3");
 }
 

--- a/src/gamefallout3.cpp
+++ b/src/gamefallout3.cpp
@@ -51,7 +51,9 @@ bool GameFallout3::init(IOrganizer* moInfo)
 
 void GameFallout3::checkVariants()
 {
-  if (QFile::exists(m_GamePath + "/Galaxy.dll")) {
+  if (QFile::exists(m_GamePath + "/Fallout3ng.exe")) {
+    setGameVariant("Low Violence");
+  } else if (QFile::exists(m_GamePath + "/Galaxy.dll")) {
     setGameVariant("GOG");
   } else if (QFile::exists(m_GamePath + "/FalloutLauncherEpic.exe")) {
     setGameVariant("Epic Games");
@@ -214,7 +216,17 @@ QStringList GameFallout3::primaryPlugins() const
 
 QStringList GameFallout3::gameVariants() const
 {
-  return {"Steam (Regular)", "Steam (Game Of The Year)", "Epic Games", "GOG"};
+  return {"Steam (Regular)", "Steam (Game Of The Year)", "Epic Games", "GOG",
+          "Low Violence"};
+}
+
+QString GameFallout3::binaryName() const
+{
+  if (selectedVariant() == "Low Violence") {
+    return "Fallout3ng.exe";
+  } else {
+    return GameGamebryo::binaryName();
+  }
 }
 
 QString GameFallout3::gameShortName() const
@@ -260,7 +272,8 @@ QString GameFallout3::getLauncherName() const
       {"Steam (Regular)", "Fallout3Launcher.exe"},
       {"Steam (Game of the Year)", "Fallout3Launcher.exe"},
       {"Epic Games", "FalloutLauncherEpic.exe"},
-      {"GOG", "FalloutLauncher.exe"}};
+      {"GOG", "FalloutLauncher.exe"},
+      {"Low Violence", "Fallout3Launcher.exe"}};
 
   return names.value(selectedVariant());
 }

--- a/src/gamefallout3.h
+++ b/src/gamefallout3.h
@@ -49,6 +49,9 @@ protected:
   virtual QString savegameExtension() const override;
   virtual QString savegameSEExtension() const override;
   std::shared_ptr<const GamebryoSaveGame> makeSaveGame(QString filePath) const override;
+
+private:
+  void checkVariants();
 };
 
 #endif  // GAMEFALLOUT3_H

--- a/src/gamefallout3.h
+++ b/src/gamefallout3.h
@@ -52,7 +52,7 @@ protected:
   std::shared_ptr<const GamebryoSaveGame> makeSaveGame(QString filePath) const override;
 
 private:
-  void checkVariants();
+  QString identifyVariant() const;
 };
 
 #endif  // GAMEFALLOUT3_H

--- a/src/gamefallout3.h
+++ b/src/gamefallout3.h
@@ -27,6 +27,7 @@ public:  // IPluginGame interface
   virtual QString steamAPPId() const override;
   virtual QStringList primaryPlugins() const override;
   virtual QStringList gameVariants() const;
+  QString binaryName() const override;
   virtual QString gameShortName() const override;
   virtual QStringList validShortNames() const override;
   virtual QString gameNexusName() const override;


### PR DESCRIPTION
These changes are based on the ModdingLinked fork of the plugin. The unused custom.ini is removed and a few variants are added to cover different launcher and main binary names.